### PR TITLE
whitelist index.js, to not have extra files published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.2",
   "description": "Check if a file is valid UTF-8",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "bin": {
     "check-utf8": "./index.js"
   },


### PR DESCRIPTION
its quite a good practice to not publish extra bits to npm, though regarding yarn.lock, its only make sense to keep it in a repo, but not in npm, because app level yarn will not respect it anyway